### PR TITLE
LICENSE: actually fill in placeholder fields

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) {{{year}}} {{{fullname}}}
+Copyright (c) 2014-2015 Iury de oliveira gomes figueiredo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add the name of the Copyright holder and years of release to the LICENSE file.

(I noticed that the placeholders had been left in when checking out which licence this code was released under.)
