### PR TITLE
Open inexisting files

### DIFF
--- a/vyapp/areavi.py
+++ b/vyapp/areavi.py
@@ -1414,9 +1414,10 @@ class AreaVi(Text):
 
         data = self.get('1.0', 'end')
         data = data.encode('utf-8')
-        fd = open(self.filename, 'w')
-        fd.write(data)
-        fd.close()
+
+        with open(self.filename, 'w') as fd:
+            fd.write(data)
+
         self.event_generate('<<SaveData>>')
 
         type, _ = mimetypes.guess_type(self.filename)

--- a/vyapp/areavi.py
+++ b/vyapp/areavi.py
@@ -1383,10 +1383,20 @@ class AreaVi(Text):
         filename = os.path.abspath(filename)        
         self.delete('1.0', 'end')
 
-        fd   = open(filename, 'r')
-        data = fd.read()
+        # check if filename exists and is a file before opening
+        # this may lead to a bug, need more testing
+        mode = ''
+        if os.path.exists(filename) and os.path.isfile(filename):
+            mode = 'r'
+        else:
+            mode = 'w+' # this will create the file
 
-        fd.close()
+        # if the file already exists, this will open in read-only mode
+        # else, it will write the file and make it exist
+        # not the best solution, but makes it behave
+        with open(filename, mode) as fd:
+            data = fd.read()
+
         self.insert('1.0', data)
 
         self.filename = filename


### PR DESCRIPTION
When opening a file that does not already exist, it is expected that the editor opens a blank file. Vy does no such thing (instead, it crashes).

I'm not entirely sure this is the best solution, but it is sure to create the new file or open an existing one. Since I'm also checking if `filename` is a file (and not a directory), this may lead to another bug where a file with the same name of the directory is created. I'm not sure at the moment how to fix this nor if it in fact may happen.

Also, changed the opening of files. Previously, it was

```
file = open(filename, mode)
file.read()
file.close()
```

this can be changed to the more pythonic

```
with open(filename, mode) as f:
    f.read()
```

that will also handle `f.close()`. This change, however, is purely aesthetic and should not compromise the program's behavior.
