### PR TITLE
Ported to python3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+This version installs both python2 and python3 versions of vy.
+
+To install the python3 version, run 
+```
+# python3 setup.py install
+```
+
+Also requires untwisted in python3-flavor, as well as python3-tkinter and python3-pygments.
+
 ![vy](vy.gif) vy
 ================
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #! /usr/bin/env python
 
 from distutils.core import setup
+
+try:
+   from distutils.command.build_py import build_py_2to3 \
+        as build_py
+except ImportError:
+   from distutils.command.build_py import build_py
+
 setup(name="vy",
       version="0.1",
       packages=["vyapp", 
@@ -14,21 +21,6 @@ setup(name="vy",
       scripts=['vy'],
       package_data={'vyapp': ['vyrc', '/vyapp/vyrc']},
       author="Iury O. G. Figueiredo",
-      author_email="ioliveira@id.uff.br")
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+      author_email="ioliveira@id.uff.br",
+      cmdclass = {'build_py': build_py}
+)

--- a/vy
+++ b/vy
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 
     root = App()
     lst  = eval(str(opt.lst))
-    lst  = lst + map(lambda ind: [[ind]], args)
+    lst  = lst + list(map(lambda ind: [[ind]], args))
 
     if not lst: root.note.create('None')
     else: root.note.load(*lst)

--- a/vyapp/stdout.py
+++ b/vyapp/stdout.py
@@ -38,6 +38,8 @@ class Transmitter(object):
 
     def write(self, data):
         for ind in self.base: 
+            if sys.version_info >= (3, 0):
+                data = str(data)
             ind.write(data)
 
 def echo(data): 


### PR DESCRIPTION
This will install vy in the python version that setup.py is called with. i.e:

```
# python setup.py install
```

installs the python2 version on most systems,

```
# python3 setup.py install
```

installs the python3 version.

Python3 also requires python3-tkinter and python3-pygments. Also requires untwisted in python3 flavor, see there.
